### PR TITLE
Implement Coinbase OAuth session flow

### DIFF
--- a/CoinbaseOauthDemo/CoinbaseOauthDemo.csproj
+++ b/CoinbaseOauthDemo/CoinbaseOauthDemo.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/CoinbaseOauthDemo/Pages/CoinbaseOauth.cshtml
+++ b/CoinbaseOauthDemo/Pages/CoinbaseOauth.cshtml
@@ -1,0 +1,48 @@
+@page
+@model CoinbaseOauthDemo.Pages.CoinbaseOauthModel
+@{
+    ViewData["Title"] = "Coinbase OAuth";
+}
+
+<h1>Coinbase OAuth Demo</h1>
+
+@if (!string.IsNullOrEmpty(Model.ErrorMessage))
+{
+    <div class="alert alert-danger" role="alert">
+        @Model.ErrorMessage
+    </div>
+}
+
+@if (!string.IsNullOrEmpty(Model.AuthorizationCode))
+{
+    <p><strong>Código recibido:</strong> <code>@Model.AuthorizationCode</code></p>
+}
+
+@if (!string.IsNullOrEmpty(Model.AccessToken))
+{
+    <div class="alert alert-success" role="alert">
+        <p><strong>Token de acceso obtenido:</strong></p>
+        <pre class="bg-light p-2">@Model.AccessToken</pre>
+    </div>
+}
+
+@if (!Model.FlowCompleted)
+{
+    if (!string.IsNullOrEmpty(Model.State))
+    {
+        <p><strong>State generado:</strong> <code>@Model.State</code></p>
+    }
+
+    if (!string.IsNullOrEmpty(Model.AuthorizationUrl))
+    {
+        <a class="btn btn-primary" href="@Model.AuthorizationUrl">Conectar con Coinbase</a>
+    }
+    else
+    {
+        <button class="btn btn-primary" disabled>Configura tus credenciales</button>
+    }
+}
+else
+{
+    <button class="btn btn-primary" disabled>Flujo completado</button>
+}

--- a/CoinbaseOauthDemo/Pages/CoinbaseOauth.cshtml.cs
+++ b/CoinbaseOauthDemo/Pages/CoinbaseOauth.cshtml.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Configuration;
+
+namespace CoinbaseOauthDemo.Pages;
+
+public class CoinbaseOauthModel : PageModel
+{
+    private const string SessionKey = "coinbase_oauth_state";
+    private readonly IConfiguration _configuration;
+
+    public CoinbaseOauthModel(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    public string? State { get; private set; }
+    public string? AuthorizationCode { get; private set; }
+    public string? AccessToken { get; private set; }
+    public string? ErrorMessage { get; private set; }
+    public string? AuthorizationUrl { get; private set; }
+    public bool FlowCompleted => !string.IsNullOrEmpty(AccessToken) || !string.IsNullOrEmpty(ErrorMessage);
+
+    public async Task OnGetAsync()
+    {
+        AuthorizationCode = Request.Query["code"];
+        var returnedState = Request.Query["state"].ToString();
+
+        if (string.IsNullOrEmpty(AuthorizationCode))
+        {
+            GenerateAuthorizationRequest();
+            return;
+        }
+
+        State = HttpContext.Session.GetString(SessionKey);
+
+        if (string.IsNullOrEmpty(returnedState) || string.IsNullOrEmpty(State) || !string.Equals(State, returnedState, StringComparison.Ordinal))
+        {
+            ErrorMessage = "El parámetro state recibido no es válido.";
+            return;
+        }
+
+        HttpContext.Session.Remove(SessionKey);
+
+        var clientId = _configuration["Coinbase:ClientId"];
+        var clientSecret = _configuration["Coinbase:ClientSecret"];
+        var redirectUri = _configuration["Coinbase:RedirectUri"];
+
+        if (string.IsNullOrEmpty(clientId) || string.IsNullOrEmpty(clientSecret) || string.IsNullOrEmpty(redirectUri))
+        {
+            ErrorMessage = "Configura Coinbase:ClientId, Coinbase:ClientSecret y Coinbase:RedirectUri antes de continuar.";
+            return;
+        }
+
+        var tokenRequest = new Dictionary<string, string>
+        {
+            ["grant_type"] = "authorization_code",
+            ["code"] = AuthorizationCode!,
+            ["client_id"] = clientId,
+            ["client_secret"] = clientSecret,
+            ["redirect_uri"] = redirectUri,
+        };
+
+        try
+        {
+            using var httpClient = new HttpClient();
+            using var content = new FormUrlEncodedContent(tokenRequest);
+            using var response = await httpClient.PostAsync("https://api.coinbase.com/oauth/token", content);
+            var body = await response.Content.ReadAsStringAsync();
+
+            if (!response.IsSuccessStatusCode)
+            {
+                ErrorMessage = $"Fallo al obtener el token de acceso: {(int)response.StatusCode} {response.ReasonPhrase}.";
+                return;
+            }
+
+            using var json = JsonDocument.Parse(body);
+            if (json.RootElement.TryGetProperty("access_token", out var accessTokenElement))
+            {
+                AccessToken = accessTokenElement.GetString();
+            }
+
+            if (string.IsNullOrEmpty(AccessToken))
+            {
+                ErrorMessage = "La respuesta de Coinbase no contiene un token de acceso.";
+            }
+        }
+        catch (HttpRequestException ex)
+        {
+            ErrorMessage = $"Error de red al intercambiar el código: {ex.Message}";
+        }
+        catch (JsonException ex)
+        {
+            ErrorMessage = $"No se pudo interpretar la respuesta de Coinbase: {ex.Message}";
+        }
+    }
+
+    private void GenerateAuthorizationRequest()
+    {
+        State = Guid.NewGuid().ToString("N");
+        HttpContext.Session.SetString(SessionKey, State);
+
+        var clientId = _configuration["Coinbase:ClientId"];
+        var redirectUri = _configuration["Coinbase:RedirectUri"];
+        var scope = _configuration["Coinbase:Scope"] ?? "wallet:user:read";
+
+        if (string.IsNullOrEmpty(clientId) || string.IsNullOrEmpty(redirectUri))
+        {
+            ErrorMessage = "Configura Coinbase:ClientId y Coinbase:RedirectUri para iniciar el flujo de autorización.";
+            return;
+        }
+
+        AuthorizationUrl = string.Join(string.Empty,
+            "https://www.coinbase.com/oauth/authorize",
+            "?response_type=code",
+            "&client_id=", Uri.EscapeDataString(clientId),
+            "&redirect_uri=", Uri.EscapeDataString(redirectUri),
+            "&state=", Uri.EscapeDataString(State!),
+            "&scope=", Uri.EscapeDataString(scope));
+    }
+}

--- a/CoinbaseOauthDemo/Pages/_ViewImports.cshtml
+++ b/CoinbaseOauthDemo/Pages/_ViewImports.cshtml
@@ -1,0 +1,3 @@
+@using CoinbaseOauthDemo
+@namespace CoinbaseOauthDemo.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/CoinbaseOauthDemo/Program.cs
+++ b/CoinbaseOauthDemo/Program.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorPages();
+builder.Services.AddDistributedMemoryCache();
+builder.Services.AddSession(options =>
+{
+    options.Cookie.HttpOnly = true;
+    options.Cookie.IsEssential = true;
+});
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error");
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+
+app.UseRouting();
+app.UseSession();
+
+app.UseAuthorization();
+
+app.MapRazorPages();
+
+app.Run();

--- a/CoinbaseOauthDemo/README.md
+++ b/CoinbaseOauthDemo/README.md
@@ -1,0 +1,9 @@
+# Coinbase OAuth Demo
+
+Esta muestra ilustra cómo ejecutar el flujo de autorización de Coinbase desde una Razor Page. El flujo completo ahora incluye:
+
+1. **Generación de `state`**: Cuando se visita la página sin un código de autorización, la aplicación genera un valor `state` aleatorio, lo guarda en la sesión del usuario y lo agrega a la URL de autorización de Coinbase.
+2. **Persistencia con sesión**: El middleware de sesiones almacena el `state` generado de forma segura entre solicitudes para poder validarlo después del redireccionamiento de Coinbase.
+3. **Intercambio automático del código**: Una vez que Coinbase redirige de regreso con un `code`, la página valida que el `state` coincida con el guardado y envía una solicitud `POST` a `https://api.coinbase.com/oauth/token` para intercambiarlo por tokens. El token de acceso obtenido se muestra en la interfaz o, en caso de error, se presentan los mensajes correspondientes.
+
+Configura en `appsettings.json` o variables de entorno los valores `Coinbase:ClientId`, `Coinbase:ClientSecret`, `Coinbase:RedirectUri` y, opcionalmente, `Coinbase:Scope` para que la demostración funcione correctamente.


### PR DESCRIPTION
## Summary
- enable session state for the demo application and configure Razor pages
- persist and validate the OAuth state while exchanging the authorization code for tokens
- surface the resulting token or errors in the UI and document the updated flow

## Testing
- dotnet build CoinbaseOauthDemo *(fails: `dotnet` is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e07e4a0c8325a7dfec8b3fcf3e5a